### PR TITLE
chore: configure postgres with docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '3.7'
+
+services:
+  financial-control-service:
+    build:
+      context: .
+    image: polymatus/financial-control-service
+    hostname: financial-control-service
+    ports:
+      - "8000:8000"
+    init: true
+    depends_on:
+      - database
+  database:
+    image: postgres:16.1-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=financial_control_service
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres


### PR DESCRIPTION
The database can be access when running:

```sh
docker exec -it financial-control-service_database_1 psql -U postgres -d financial_control_service
``` 

Closes #3 